### PR TITLE
Prime Factors Kata

### DIFF
--- a/PrimeFactors/PrimeFactors.xcodeproj/project.pbxproj
+++ b/PrimeFactors/PrimeFactors.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		E5473B542324425A008D5C97 /* PrimeFactors.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E5473B4A2324425A008D5C97 /* PrimeFactors.framework */; };
 		E5473B6523244287008D5C97 /* PrimeFactorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5473B6423244287008D5C97 /* PrimeFactorsTests.swift */; };
+		E5473B6923244A74008D5C97 /* PrimeFactors.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5473B6823244A74008D5C97 /* PrimeFactors.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -27,6 +28,7 @@
 		E5473B532324425A008D5C97 /* PrimeFactorsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PrimeFactorsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E5473B5A2324425A008D5C97 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E5473B6423244287008D5C97 /* PrimeFactorsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimeFactorsTests.swift; sourceTree = "<group>"; };
+		E5473B6823244A74008D5C97 /* PrimeFactors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimeFactors.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -69,6 +71,7 @@
 		E5473B4C2324425A008D5C97 /* PrimeFactors */ = {
 			isa = PBXGroup;
 			children = (
+				E5473B6823244A74008D5C97 /* PrimeFactors.swift */,
 				E5473B4E2324425A008D5C97 /* Info.plist */,
 			);
 			path = PrimeFactors;
@@ -144,6 +147,7 @@
 				TargetAttributes = {
 					E5473B492324425A008D5C97 = {
 						CreatedOnToolsVersion = 11.0;
+						LastSwiftMigration = 1100;
 					};
 					E5473B522324425A008D5C97 = {
 						CreatedOnToolsVersion = 11.0;
@@ -192,6 +196,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E5473B6923244A74008D5C97 /* PrimeFactors.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -336,6 +341,7 @@
 		E5473B5F2324425A008D5C97 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
@@ -352,6 +358,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.fabiomignogna.PrimeFactors;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -359,6 +366,7 @@
 		E5473B602324425A008D5C97 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
@@ -382,6 +390,7 @@
 		E5473B622324425A008D5C97 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -401,6 +410,7 @@
 		E5473B632324425A008D5C97 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;

--- a/PrimeFactors/PrimeFactors.xcodeproj/project.pbxproj
+++ b/PrimeFactors/PrimeFactors.xcodeproj/project.pbxproj
@@ -1,0 +1,444 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		E5473B542324425A008D5C97 /* PrimeFactors.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E5473B4A2324425A008D5C97 /* PrimeFactors.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		E5473B552324425A008D5C97 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E5473B412324425A008D5C97 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E5473B492324425A008D5C97;
+			remoteInfo = PrimeFactors;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		E5473B4A2324425A008D5C97 /* PrimeFactors.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PrimeFactors.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E5473B4E2324425A008D5C97 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E5473B532324425A008D5C97 /* PrimeFactorsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PrimeFactorsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		E5473B5A2324425A008D5C97 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		E5473B472324425A008D5C97 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E5473B502324425A008D5C97 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E5473B542324425A008D5C97 /* PrimeFactors.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		E5473B402324425A008D5C97 = {
+			isa = PBXGroup;
+			children = (
+				E5473B4C2324425A008D5C97 /* PrimeFactors */,
+				E5473B572324425A008D5C97 /* PrimeFactorsTests */,
+				E5473B4B2324425A008D5C97 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		E5473B4B2324425A008D5C97 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				E5473B4A2324425A008D5C97 /* PrimeFactors.framework */,
+				E5473B532324425A008D5C97 /* PrimeFactorsTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		E5473B4C2324425A008D5C97 /* PrimeFactors */ = {
+			isa = PBXGroup;
+			children = (
+				E5473B4E2324425A008D5C97 /* Info.plist */,
+			);
+			path = PrimeFactors;
+			sourceTree = "<group>";
+		};
+		E5473B572324425A008D5C97 /* PrimeFactorsTests */ = {
+			isa = PBXGroup;
+			children = (
+				E5473B5A2324425A008D5C97 /* Info.plist */,
+			);
+			path = PrimeFactorsTests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		E5473B452324425A008D5C97 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		E5473B492324425A008D5C97 /* PrimeFactors */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E5473B5E2324425A008D5C97 /* Build configuration list for PBXNativeTarget "PrimeFactors" */;
+			buildPhases = (
+				E5473B452324425A008D5C97 /* Headers */,
+				E5473B462324425A008D5C97 /* Sources */,
+				E5473B472324425A008D5C97 /* Frameworks */,
+				E5473B482324425A008D5C97 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = PrimeFactors;
+			productName = PrimeFactors;
+			productReference = E5473B4A2324425A008D5C97 /* PrimeFactors.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		E5473B522324425A008D5C97 /* PrimeFactorsTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E5473B612324425A008D5C97 /* Build configuration list for PBXNativeTarget "PrimeFactorsTests" */;
+			buildPhases = (
+				E5473B4F2324425A008D5C97 /* Sources */,
+				E5473B502324425A008D5C97 /* Frameworks */,
+				E5473B512324425A008D5C97 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				E5473B562324425A008D5C97 /* PBXTargetDependency */,
+			);
+			name = PrimeFactorsTests;
+			productName = PrimeFactorsTests;
+			productReference = E5473B532324425A008D5C97 /* PrimeFactorsTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		E5473B412324425A008D5C97 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1100;
+				LastUpgradeCheck = 1100;
+				ORGANIZATIONNAME = "Fabio Mignogna";
+				TargetAttributes = {
+					E5473B492324425A008D5C97 = {
+						CreatedOnToolsVersion = 11.0;
+					};
+					E5473B522324425A008D5C97 = {
+						CreatedOnToolsVersion = 11.0;
+					};
+				};
+			};
+			buildConfigurationList = E5473B442324425A008D5C97 /* Build configuration list for PBXProject "PrimeFactors" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = E5473B402324425A008D5C97;
+			productRefGroup = E5473B4B2324425A008D5C97 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				E5473B492324425A008D5C97 /* PrimeFactors */,
+				E5473B522324425A008D5C97 /* PrimeFactorsTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		E5473B482324425A008D5C97 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E5473B512324425A008D5C97 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		E5473B462324425A008D5C97 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E5473B4F2324425A008D5C97 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		E5473B562324425A008D5C97 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E5473B492324425A008D5C97 /* PrimeFactors */;
+			targetProxy = E5473B552324425A008D5C97 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		E5473B5C2324425A008D5C97 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		E5473B5D2324425A008D5C97 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = macosx;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		E5473B5F2324425A008D5C97 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = PrimeFactors/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.fabiomignogna.PrimeFactors;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		E5473B602324425A008D5C97 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = PrimeFactors/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.fabiomignogna.PrimeFactors;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		E5473B622324425A008D5C97 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = PrimeFactorsTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.fabiomignogna.PrimeFactorsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		E5473B632324425A008D5C97 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = PrimeFactorsTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.fabiomignogna.PrimeFactorsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		E5473B442324425A008D5C97 /* Build configuration list for PBXProject "PrimeFactors" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E5473B5C2324425A008D5C97 /* Debug */,
+				E5473B5D2324425A008D5C97 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E5473B5E2324425A008D5C97 /* Build configuration list for PBXNativeTarget "PrimeFactors" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E5473B5F2324425A008D5C97 /* Debug */,
+				E5473B602324425A008D5C97 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E5473B612324425A008D5C97 /* Build configuration list for PBXNativeTarget "PrimeFactorsTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E5473B622324425A008D5C97 /* Debug */,
+				E5473B632324425A008D5C97 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = E5473B412324425A008D5C97 /* Project object */;
+}

--- a/PrimeFactors/PrimeFactors.xcodeproj/project.pbxproj
+++ b/PrimeFactors/PrimeFactors.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		E5473B542324425A008D5C97 /* PrimeFactors.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E5473B4A2324425A008D5C97 /* PrimeFactors.framework */; };
+		E5473B6523244287008D5C97 /* PrimeFactorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5473B6423244287008D5C97 /* PrimeFactorsTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -25,6 +26,7 @@
 		E5473B4E2324425A008D5C97 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E5473B532324425A008D5C97 /* PrimeFactorsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PrimeFactorsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E5473B5A2324425A008D5C97 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E5473B6423244287008D5C97 /* PrimeFactorsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimeFactorsTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -75,6 +77,7 @@
 		E5473B572324425A008D5C97 /* PrimeFactorsTests */ = {
 			isa = PBXGroup;
 			children = (
+				E5473B6423244287008D5C97 /* PrimeFactorsTests.swift */,
 				E5473B5A2324425A008D5C97 /* Info.plist */,
 			);
 			path = PrimeFactorsTests;
@@ -144,6 +147,7 @@
 					};
 					E5473B522324425A008D5C97 = {
 						CreatedOnToolsVersion = 11.0;
+						LastSwiftMigration = 1100;
 					};
 				};
 			};
@@ -195,6 +199,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E5473B6523244287008D5C97 /* PrimeFactorsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -377,6 +382,7 @@
 		E5473B622324425A008D5C97 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = PrimeFactorsTests/Info.plist;
@@ -387,6 +393,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.fabiomignogna.PrimeFactorsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -394,6 +401,7 @@
 		E5473B632324425A008D5C97 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = PrimeFactorsTests/Info.plist;

--- a/PrimeFactors/PrimeFactors.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/PrimeFactors/PrimeFactors.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:PrimeFactors.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/PrimeFactors/PrimeFactors.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/PrimeFactors/PrimeFactors.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/PrimeFactors/PrimeFactors/Info.plist
+++ b/PrimeFactors/PrimeFactors/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2019 Fabio Mignogna. All rights reserved.</string>
+</dict>
+</plist>

--- a/PrimeFactors/PrimeFactors/PrimeFactors.swift
+++ b/PrimeFactors/PrimeFactors/PrimeFactors.swift
@@ -1,0 +1,25 @@
+//
+//  PrimeFactors.swift
+//  PrimeFactors
+//
+//  Created by Fabio Mignogna on 07/09/2019.
+//  Copyright © 2019 Fabio Mignogna. All rights reserved.
+//
+
+public class PrimeFactors {
+    
+    public init() {}
+    
+    public func generate(_ n: inout Int) -> [Int] {
+        var factors = [Int]()
+        var divisor = 2
+        while n > 1 {
+            while n % divisor == 0 {
+                factors.append(divisor)
+                n /= divisor
+            }
+            divisor += 1
+        }
+        return factors
+    }
+}

--- a/PrimeFactors/PrimeFactorsTests/Info.plist
+++ b/PrimeFactors/PrimeFactorsTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/PrimeFactors/PrimeFactorsTests/PrimeFactorsTests.swift
+++ b/PrimeFactors/PrimeFactorsTests/PrimeFactorsTests.swift
@@ -9,17 +9,18 @@
 import XCTest
 
 class PrimeFactors {
+    
     func generate(_ n: inout Int) -> [Int] {
-        var output = [Int]()
-        var p = 2
+        var factors = [Int]()
+        var divisor = 2
         while n > 1 {
-            while n % p == 0 {
-                output.append(p)
-                n /= p
+            while n % divisor == 0 {
+                factors.append(divisor)
+                n /= divisor
             }
-            p += 1
+            divisor += 1
         }
-        return output
+        return factors
     }
 }
 

--- a/PrimeFactors/PrimeFactorsTests/PrimeFactorsTests.swift
+++ b/PrimeFactors/PrimeFactorsTests/PrimeFactorsTests.swift
@@ -12,7 +12,7 @@ class PrimeFactors {
     func generate(_ n: inout Int) -> [Int] {
         var output = [Int]()
         if n > 1 {
-            if n % 2 == 0 {
+            while n % 2 == 0 {
                 output.append(2)
                 n /= 2
             }
@@ -54,6 +54,10 @@ class PrimeFactorsTests: XCTestCase {
     
     func test_generate_with7AsInput_shouldReturn_7() {
         assertThatPrimeFactorsOf(7, isEqualTo: [7])
+    }
+    
+    func test_generate_with8AsInput_shouldReturn_2_2_2() {
+        assertThatPrimeFactorsOf(8, isEqualTo: [2,2,2])
     }
     
     // MARK: Helpers

--- a/PrimeFactors/PrimeFactorsTests/PrimeFactorsTests.swift
+++ b/PrimeFactors/PrimeFactorsTests/PrimeFactorsTests.swift
@@ -19,13 +19,13 @@ class PrimeFactors {
 
 class PrimeFactorsTests: XCTestCase {
     
+    private let sut = PrimeFactors()
+    
     func test_generate_with1AsInput_shouldReturnAnEmptyArray() {
-        let sut = PrimeFactors()
         XCTAssertEqual(sut.generate(1), [])
     }
     
     func test_generate_with2AsInput_shouldReturn_2() {
-        let sut = PrimeFactors()
         XCTAssertEqual(sut.generate(2), [2])
     }
 }

--- a/PrimeFactors/PrimeFactorsTests/PrimeFactorsTests.swift
+++ b/PrimeFactors/PrimeFactorsTests/PrimeFactorsTests.swift
@@ -10,6 +10,9 @@ import XCTest
 
 class PrimeFactors {
     func generate(_ input: Int) -> [Int] {
+        if input > 1 {
+            return [2]
+        }
         return []
     }
 }
@@ -19,5 +22,10 @@ class PrimeFactorsTests: XCTestCase {
     func test_generate_with1AsInput_shouldReturnAnEmptyArray() {
         let sut = PrimeFactors()
         XCTAssertEqual(sut.generate(1), [])
+    }
+    
+    func test_generate_with2AsInput_shouldReturn_2() {
+        let sut = PrimeFactors()
+        XCTAssertEqual(sut.generate(2), [2])
     }
 }

--- a/PrimeFactors/PrimeFactorsTests/PrimeFactorsTests.swift
+++ b/PrimeFactors/PrimeFactorsTests/PrimeFactorsTests.swift
@@ -48,6 +48,10 @@ class PrimeFactorsTests: XCTestCase {
         assertThatPrimeFactorsOf(5, isEqualTo: [5])
     }
     
+    func test_generate_with6AsInput_shouldReturn_2_3() {
+        assertThatPrimeFactorsOf(6, isEqualTo: [2,3])
+    }
+    
     // MARK: Helpers
     
     private func assertThatPrimeFactorsOf(_ input: Int, isEqualTo expected: [Int], file: StaticString = #file, line: UInt = #line) {

--- a/PrimeFactors/PrimeFactorsTests/PrimeFactorsTests.swift
+++ b/PrimeFactors/PrimeFactorsTests/PrimeFactorsTests.swift
@@ -10,10 +10,18 @@ import XCTest
 
 class PrimeFactors {
     func generate(_ input: Int) -> [Int] {
+        var n = input
+        var output = [Int]()
         if input > 1 {
-            return [input]
+            if input % 2 == 0 {
+                output.append(2)
+                n /= 2
+            }
+            if n > 1 {
+                output.append(n)
+            }
         }
-        return []
+        return output
     }
 }
 
@@ -31,5 +39,9 @@ class PrimeFactorsTests: XCTestCase {
     
     func test_generate_with3AsInput_shouldReturn_3() {
         XCTAssertEqual(sut.generate(3), [3])
+    }
+    
+    func test_generate_with4AsInput_shouldReturn_2_2() {
+        XCTAssertEqual(sut.generate(4), [2,2])
     }
 }

--- a/PrimeFactors/PrimeFactorsTests/PrimeFactorsTests.swift
+++ b/PrimeFactors/PrimeFactorsTests/PrimeFactorsTests.swift
@@ -64,6 +64,11 @@ class PrimeFactorsTests: XCTestCase {
         assertThatPrimeFactorsOf(9, isEqualTo: [3,3])
     }
     
+    func test_generate_acceptanceTest() {
+        let n = 2*2*3*3*5*7*11
+        assertThatPrimeFactorsOf(n, isEqualTo: [2,2,3,3,5,7,11])
+    }
+    
     // MARK: Helpers
     
     private func assertThatPrimeFactorsOf(_ input: Int, isEqualTo expected: [Int], file: StaticString = #file, line: UInt = #line) {

--- a/PrimeFactors/PrimeFactorsTests/PrimeFactorsTests.swift
+++ b/PrimeFactors/PrimeFactorsTests/PrimeFactorsTests.swift
@@ -44,6 +44,10 @@ class PrimeFactorsTests: XCTestCase {
         assertThatPrimeFactorsOf(4, isEqualTo: [2,2])
     }
     
+    func test_generate_with5AsInput_shouldReturn_5() {
+        assertThatPrimeFactorsOf(5, isEqualTo: [5])
+    }
+    
     // MARK: Helpers
     
     private func assertThatPrimeFactorsOf(_ input: Int, isEqualTo expected: [Int], file: StaticString = #file, line: UInt = #line) {

--- a/PrimeFactors/PrimeFactorsTests/PrimeFactorsTests.swift
+++ b/PrimeFactors/PrimeFactorsTests/PrimeFactorsTests.swift
@@ -11,14 +11,13 @@ import XCTest
 class PrimeFactors {
     func generate(_ n: inout Int) -> [Int] {
         var output = [Int]()
-        if n > 1 {
-            while n % 2 == 0 {
-                output.append(2)
-                n /= 2
+        var p = 2
+        while n > 1 {
+            while n % p == 0 {
+                output.append(p)
+                n /= p
             }
-            if n > 1 {
-                output.append(n)
-            }
+            p += 1
         }
         return output
     }
@@ -58,6 +57,10 @@ class PrimeFactorsTests: XCTestCase {
     
     func test_generate_with8AsInput_shouldReturn_2_2_2() {
         assertThatPrimeFactorsOf(8, isEqualTo: [2,2,2])
+    }
+    
+    func test_generate_with9AsInput_shouldReturn_3_3() {
+        assertThatPrimeFactorsOf(9, isEqualTo: [3,3])
     }
     
     // MARK: Helpers

--- a/PrimeFactors/PrimeFactorsTests/PrimeFactorsTests.swift
+++ b/PrimeFactors/PrimeFactorsTests/PrimeFactorsTests.swift
@@ -52,6 +52,10 @@ class PrimeFactorsTests: XCTestCase {
         assertThatPrimeFactorsOf(6, isEqualTo: [2,3])
     }
     
+    func test_generate_with7AsInput_shouldReturn_7() {
+        assertThatPrimeFactorsOf(7, isEqualTo: [7])
+    }
+    
     // MARK: Helpers
     
     private func assertThatPrimeFactorsOf(_ input: Int, isEqualTo expected: [Int], file: StaticString = #file, line: UInt = #line) {

--- a/PrimeFactors/PrimeFactorsTests/PrimeFactorsTests.swift
+++ b/PrimeFactors/PrimeFactorsTests/PrimeFactorsTests.swift
@@ -1,0 +1,23 @@
+//
+//  PrimeFactorsTests.swift
+//  PrimeFactorsTests
+//
+//  Created by Fabio Mignogna on 07/09/2019.
+//  Copyright © 2019 Fabio Mignogna. All rights reserved.
+//
+
+import XCTest
+
+class PrimeFactors {
+    func generate(_ input: Int) -> [Int] {
+        return []
+    }
+}
+
+class PrimeFactorsTests: XCTestCase {
+    
+    func test_generate_with1AsInput_shouldReturnAnEmptyArray() {
+        let sut = PrimeFactors()
+        XCTAssertEqual(sut.generate(1), [])
+    }
+}

--- a/PrimeFactors/PrimeFactorsTests/PrimeFactorsTests.swift
+++ b/PrimeFactors/PrimeFactorsTests/PrimeFactorsTests.swift
@@ -11,7 +11,7 @@ import XCTest
 class PrimeFactors {
     func generate(_ input: Int) -> [Int] {
         if input > 1 {
-            return [2]
+            return [input]
         }
         return []
     }
@@ -27,5 +27,9 @@ class PrimeFactorsTests: XCTestCase {
     
     func test_generate_with2AsInput_shouldReturn_2() {
         XCTAssertEqual(sut.generate(2), [2])
+    }
+    
+    func test_generate_with3AsInput_shouldReturn_3() {
+        XCTAssertEqual(sut.generate(3), [3])
     }
 }

--- a/PrimeFactors/PrimeFactorsTests/PrimeFactorsTests.swift
+++ b/PrimeFactors/PrimeFactorsTests/PrimeFactorsTests.swift
@@ -9,11 +9,10 @@
 import XCTest
 
 class PrimeFactors {
-    func generate(_ input: Int) -> [Int] {
-        var n = input
+    func generate(_ n: inout Int) -> [Int] {
         var output = [Int]()
-        if input > 1 {
-            if input % 2 == 0 {
+        if n > 1 {
+            if n % 2 == 0 {
                 output.append(2)
                 n /= 2
             }
@@ -30,18 +29,25 @@ class PrimeFactorsTests: XCTestCase {
     private let sut = PrimeFactors()
     
     func test_generate_with1AsInput_shouldReturnAnEmptyArray() {
-        XCTAssertEqual(sut.generate(1), [])
+        assertThatPrimeFactorsOf(1, isEqualTo: [])
     }
     
     func test_generate_with2AsInput_shouldReturn_2() {
-        XCTAssertEqual(sut.generate(2), [2])
+        assertThatPrimeFactorsOf(2, isEqualTo: [2])
     }
     
     func test_generate_with3AsInput_shouldReturn_3() {
-        XCTAssertEqual(sut.generate(3), [3])
+        assertThatPrimeFactorsOf(3, isEqualTo: [3])
     }
     
     func test_generate_with4AsInput_shouldReturn_2_2() {
-        XCTAssertEqual(sut.generate(4), [2,2])
+        assertThatPrimeFactorsOf(4, isEqualTo: [2,2])
+    }
+    
+    // MARK: Helpers
+    
+    private func assertThatPrimeFactorsOf(_ input: Int, isEqualTo expected: [Int], file: StaticString = #file, line: UInt = #line) {
+        var n = input
+        XCTAssertEqual(sut.generate(&n), expected, file: file, line: line)
     }
 }

--- a/PrimeFactors/PrimeFactorsTests/PrimeFactorsTests.swift
+++ b/PrimeFactors/PrimeFactorsTests/PrimeFactorsTests.swift
@@ -7,22 +7,7 @@
 //
 
 import XCTest
-
-class PrimeFactors {
-    
-    func generate(_ n: inout Int) -> [Int] {
-        var factors = [Int]()
-        var divisor = 2
-        while n > 1 {
-            while n % divisor == 0 {
-                factors.append(divisor)
-                n /= divisor
-            }
-            divisor += 1
-        }
-        return factors
-    }
-}
+import PrimeFactors
 
 class PrimeFactorsTests: XCTestCase {
     


### PR DESCRIPTION
Write a function `generate` under a module `PrimeFactors` that, given an integer, returns the list containing the prime factors in numerical sequence.

- 1 should return `[]`
- 2 should return `[2]`
- 3 should return `[3]`
- 4 should return `[2,2]`
- 5 should return `[5]`
- 6 should return `[2,3]`
- 7 should return `[7]`
- 8 should return `[2,2,2]`
- 9 should return `[3,3]`
- 13860 should return `[2,2,3,3,5,7,11]`